### PR TITLE
Speedup dictionary creation by delaying strdup

### DIFF
--- a/spell.c
+++ b/spell.c
@@ -97,10 +97,10 @@ static int read_file(ENTRY dict)
 
         word = strtok(file, delim);
         while(word != NULL) {
-                w = strtolower(strdup(word));
+                w = strtolower(word);
 
                 if (!update(w)) {
-                        dict.key  = w;
+                        dict.key  = strdup(w);
                         dict.data = 0;
                         hsearch(dict, ENTER);
                 }


### PR DESCRIPTION
On my machine execution time went down from 0.30s 0.25s. It works, because the file contents are tokenized in-place and thrown away anyway.